### PR TITLE
Explicitly state x-axis range

### DIFF
--- a/src/barebones/core.cljs
+++ b/src/barebones/core.cljs
@@ -19,7 +19,7 @@
    (reify om/IRender
      (render [_]
              (dom/h1 nil (:text data))
-             (-> (c/histogram data)
+             (-> (c/histogram data :x-axis [0 1] :bins 20)
                  (s/as-svg :width 500 :height 200)))))
  app-state
  {:target (. js/document (getElementById "app"))})


### PR DESCRIPTION
This at least allows you to get an interactive REPL going.

I'm still getting an `Uncaught Error: Invariant Violation: ReactCompositeComponent.render(): A valid ReactComponent must be returned. You may have returned undefined, an array or some other invalid object` though.
- I'll fix the x-axis issue, I don't think there should be any requirement to pass the range explicitly.
- If a change on my part is required to get things playing nicely with Om, do feed back so I can make the necessary changes.

Swapping out for React (the only renderer I have tested with) gives the following:
![screen shot 2015-07-02 at 20 07 51](https://cloud.githubusercontent.com/assets/24540/8485529/19984f7e-20f6-11e5-94c9-28ccf5d992d9.png)
